### PR TITLE
Add .editorconfig with two-space indents and Unix newlines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
This will help avoid inconsistent indentation like the tab in my last commit. (Sorry about that!)

Most editors support .editorconfig either natively or with a plugin.

Sad but true: I meant to add a .editorconfig *before* fixing that bug. I always start a project with a .gitignore and .editorconfig before committing anything else. Live and learn, I guess. :-)