### PR TITLE
Statically link the rtlib, to support, at least, stock Win XP and Win 10

### DIFF
--- a/rcedit.gyp
+++ b/rcedit.gyp
@@ -26,6 +26,7 @@
         'VCCLCompilerTool': {
           'Optimization': 3, # /Ox, full optimization
           'FavorSizeOrSpeed': 1, # /Os, favour small code
+          'RuntimeLibrary': 0, # /MT, for statically linked runtime
         },
       },
       'conditions': [


### PR DESCRIPTION
Only increases binary size by 64kB.

Fixes issue #3 "doesn't work on fresh install of windows 10"